### PR TITLE
Fix Improper Update

### DIFF
--- a/src/options.py
+++ b/src/options.py
@@ -25,7 +25,7 @@ def open_parse_info():
     options_dict['show_parse'] = True
 
 def version():
-    print(f'Version: \033[1m{VERSION}\033[0m')
+    print(f'Version \033[1m{VERSION}\033[0m')
     exit(0)
 
 def help():


### PR DESCRIPTION
Do not use `:` in the version output, this is incompatible with the extension repo's issue template
`description: 填写你正在使用的CPC版本，例如 Version 0.1.3`